### PR TITLE
fix(dependencies): update retrofit to 3.0.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,7 @@
         <uipath-startjob.main-class>org.bonitasoft.engine.connector.uipath.UIPathStartJobsConnector</uipath-startjob.main-class>
 
         <!-- Connector dependencies -->
-        <retrofit.version>2.9.0</retrofit.version>
+        <retrofit.version>3.0.0</retrofit.version>
         <logging-interceptor.version>4.12.0</logging-interceptor.version>
         <lombok.version>1.18.30</lombok.version>
 


### PR DESCRIPTION
* use latest version of retrofit (3.0.0 compatible with 2.x version according to https://github.com/square/retrofit/releases/tag/3.0.0) This version relies on OkHttp 4.12 (same version as logging-interceptor, which is resolving transitive deps conflict)

Covers [STUDIO-4569](https://bonitasoft.atlassian.net/browse/STUDIO-4569)

[STUDIO-4569]: https://bonitasoft.atlassian.net/browse/STUDIO-4569?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ